### PR TITLE
Prevent beeping after pressing Return in textbox on Windows

### DIFF
--- a/src/NiCalc.nim
+++ b/src/NiCalc.nim
@@ -95,6 +95,8 @@ inputTextBox.onTextChange = proc(event: TextChangeEvent) =
 
 inputTextBox.onKeyDown = proc(event: ControlKeyEvent) =
   if event.key == Key_Return:
+    when defined(windows):
+      event.cancel = true # stops annoying ding sound on windows
     if lastCalculation == "":
       updateResult(nil)
     if lastCalculation != "":


### PR DESCRIPTION
Cancel the ControlKeyEvent in inputTextBox after the key is known to be the Return key. This prevents the annoying "beep" or "ding" sound Windows makes when attempting to add a newline character to a single line textbox.